### PR TITLE
Implement connecting to existing session. 

### DIFF
--- a/guacamole/client.py
+++ b/guacamole/client.py
@@ -160,7 +160,7 @@ class GuacamoleClient(object):
         self.logger.debug('Send `select` instruction.')
 
         # if connectionid is provided - connect to existing connectionid
-        if ('connectionid' in kwargs):
+        if 'connectionid' in kwargs:
             self.send_instruction(Instruction('select',
                                               kwargs.get('connectionid')))
         else:

--- a/guacamole/client.py
+++ b/guacamole/client.py
@@ -139,10 +139,13 @@ class GuacamoleClient(object):
                   audio=None, video=None, image=None, **kwargs):
         """
         Establish connection with Guacamole guacd server via handshake.
+
         """
-        if protocol not in PROTOCOLS:
-            self.logger.debug('Invalid protocol: %s' % protocol)
-            raise GuacamoleError('Cannot start Handshake. Missing protocol.')
+        if protocol not in PROTOCOLS and 'connectionid' not in kwargs:
+            self.logger.debug('Invalid protocol: %s '
+                              'and no connectionid provided' % protocol)
+            raise GuacamoleError('Cannot start Handshake. '
+                                 'Missing protocol or connectionid.')
 
         if audio is None:
             audio = list()
@@ -155,7 +158,13 @@ class GuacamoleClient(object):
 
         # 1. Send 'select' instruction
         self.logger.debug('Send `select` instruction.')
-        self.send_instruction(Instruction('select', protocol))
+
+        # if connectionid is provided - connect to existing connectionid
+        if ('connectionid' in kwargs):
+            self.send_instruction(Instruction('select',
+                                              kwargs.get('connectionid')))
+        else:
+            self.send_instruction(Instruction('select', protocol))
 
         # 2. Receive `args` instruction
         instruction = self.read_instruction()


### PR DESCRIPTION
Guacamole specs allow "selet" command to provide existing session id instead of protocol.

https://guacamole.apache.org/doc/gug/protocol-reference.html#select-instruction

ID
The name of the protocol to use, such as "vnc" or "rdp", or the ID of the active connection to be joined, as returned via the ready instruction.

In my application I implemented reconnecting to existing session, which allows same session to be shared between several users (collaborating or specatator mode), I had to do this change to support it. 